### PR TITLE
feat: add CoPilot support to Neovim

### DIFF
--- a/.config/nvim/lua/plugins/copilot.lua
+++ b/.config/nvim/lua/plugins/copilot.lua
@@ -1,0 +1,5 @@
+return {
+  {
+    "github/copilot.vim",
+  },
+}

--- a/Library/Application Support/Code - Insiders/User/settings.json
+++ b/Library/Application Support/Code - Insiders/User/settings.json
@@ -5,6 +5,20 @@
   "[markdown][typescript][yaml][html][javascript][json][jsonc][javascriptreact][scss]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "[lua]": {
+    "editor.defaultFormatter": "sumneko.lua"
+  },
+  "[markdown]": {
+    "editor.unicodeHighlight.ambiguousCharacters": false,
+    "editor.unicodeHighlight.invisibleCharacters": false,
+    "diffEditor.ignoreTrimWhitespace": false,
+    "editor.wordWrap": "on",
+    "editor.quickSuggestions": {
+      "comments": "on",
+      "strings": "on",
+      "other": "on"
+    }
+  },
   "[ruby]": {
     "editor.defaultFormatter": "Shopify.ruby-lsp",
     "editor.formatOnSave": true,
@@ -22,17 +36,6 @@
   },
   "[shellscript][properties]": {
     "editor.defaultFormatter": "foxundermoon.shell-format"
-  },
-  "[markdown]": {
-    "editor.unicodeHighlight.ambiguousCharacters": false,
-    "editor.unicodeHighlight.invisibleCharacters": false,
-    "diffEditor.ignoreTrimWhitespace": false,
-    "editor.wordWrap": "on",
-    "editor.quickSuggestions": {
-      "comments": "on",
-      "strings": "on",
-      "other": "on"
-    }
   },
   "editor.semanticHighlighting.enabled": true,
   "breadcrumbs.enabled": true,
@@ -534,11 +537,11 @@
   "githubPullRequests.fileListLayout": "flat",
   "window.titleBarStyle": "custom",
   "workbench.colorCustomizations": {
-    "statusBar.background": "#111111",
-    "statusBar.noFolderBackground": "#111111",
-    "statusBar.debuggingBackground": "#111111",
-    "statusBar.foreground": "#eeeeee",
-    "statusBar.debuggingForeground": "#eeeeee"
+    "statusBar.background": "#132d21",
+    "statusBar.noFolderBackground": "#132d21",
+    "statusBar.debuggingBackground": "#132d21",
+    "statusBar.foreground": "#b1f1cb",
+    "statusBar.debuggingForeground": "#b1f1cb"
   },
   "orion-vscode.accentColor": "blue",
   "github.copilot.chat.localeOverride": "en",


### PR DESCRIPTION
## PR Purpose

This commit adds the Copilot extension to my Neovim config.

## Changes Summary

- Neovim: Create new plugin file for copilot
- VS Code: Update Lua default formatter and reorganize the settings file

## Screenshots

Add screenshots of the feature in action or a video/GIF walkthrough of the UX. Remove if not applicable (e.g. refactoring).

## Areas of interest

After installing the plugin with Lazy, you have to run `:Copilot setup` to authenticate with GitHub and get the extension working 
