### PR TITLE
Configure chezmoi to sync zdotdir

### DIFF
--- a/dot_config/chezmoi/chezmoi.toml
+++ b/dot_config/chezmoi/chezmoi.toml
@@ -1,0 +1,5 @@
+[externals]
+  [externals."dot_config/zsh"]
+    type = "git"
+    url = "https://github.com/andrewmcodes/zdotdir.git"
+    refreshPeriod = "168h"


### PR DESCRIPTION
## Summary
- add a chezmoi configuration file
- configure an external git source for the ZSH dotfiles

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d48fb2d680832fafa1cc94acde63c3