### PR TITLE
Add documentation style guide, tidy README, and improve ANSI color reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Managed with [chezmoi](https://www.chezmoi.io/), these dotfiles keep shell, editor, and CLI configuration synchronized across machines. Files prefixed with `dot_` map directly to paths in `$HOME` (for example `dot_zshenv` → `~/.zshenv`).
 
-## Tooling Overview
+## Tooling overview
 
 | Tool | Role |
 | ---- | ---- |
@@ -32,14 +32,14 @@ Executable helpers live in `bin/`. Archived or inactive configs reside in `archi
    ```
    Run `brew bundle` if a Brewfile is present.
 
-## Common chezmoi Commands
+## Common chezmoi commands
 
 - Edit and apply a file in one step: `chezmoi edit --apply <path>`
 - Review pending changes: `chezmoi diff`
 - Re-apply everything: `chezmoi apply`
 - Adjust attributes (e.g., remove private flag): `chezmoi chattr -- -p <path>`
 
-## Repository Layout
+## Repository layout
 
 - `dot_*` files map to configuration files in `$HOME`.
 - `bin/` contains executables linked into `~/bin`.
@@ -47,6 +47,10 @@ Executable helpers live in `bin/`. Archived or inactive configs reside in `archi
 - `install/` contains idempotent installation scripts.
 - `scripts/` contains the bootstrap script and shared library functions.
 - `tests/` contains basic smoke tests to validate scripts.
+
+## Documentation
+
+For writing conventions used in this repository, see `docs/documentation-style-guide.md`.
 
 ## Testing
 
@@ -63,7 +67,7 @@ bats tests/smoke.bats
 shellcheck install/*.sh scripts/**/*.sh
 ```
 
-## Bootstrap Script
+## Bootstrap script
 
 For a fresh machine setup, use the bootstrap script:
 

--- a/docs/documentation-style-guide.md
+++ b/docs/documentation-style-guide.md
@@ -1,0 +1,107 @@
+# Documentation style guide
+
+This guide captures the writing patterns used in this repository’s existing docs and defines a consistent standard for future documentation.
+
+## Purpose
+
+Write docs that help someone set up, use, and maintain these dotfiles quickly, with minimal ambiguity and copy-paste-ready commands.
+
+## Voice and tone
+
+- **Use a practical, neutral, concise voice.** Prefer direct statements over marketing language.
+- **Be action-oriented.** Lead with verbs like “Install,” “Apply,” “Run,” and “Review.”
+- **Be confident but factual.** State what a script or tool does without overpromising.
+- **Explain just enough context.** Assume readers are technical, but do not assume they know this repo’s conventions.
+
+### Example tone
+
+- Good: “Executable helpers live in `bin/`.”
+- Avoid: “This amazing folder contains powerful automation magic.”
+
+## Structure conventions
+
+Use predictable sections so readers can scan quickly.
+
+### Recommended order for top-level docs
+
+1. **Title (`#`)**: short and specific.
+2. **One-paragraph summary**: what this doc/repo is and why it exists.
+3. **Overview section (`##`)**: key components, often a table.
+4. **Setup / Usage (`##`)**: numbered steps in execution order.
+5. **Common commands (`##`)**: short task-oriented bullets.
+6. **Layout / Architecture (`##`)**: where important files live.
+7. **Testing / Validation (`##`)**: runnable checks.
+8. **Appendix sections (`##`)**: optional deeper workflows (for example bootstrap details).
+
+### Heading style
+
+- Use **sentence case** for headings (for example, `## Tooling overview`).
+- Keep headings short and concrete.
+- Prefer `##` for major sections and `###` for subsections.
+- Avoid skipping levels (`##` directly to `####`).
+
+## Code and command formatting
+
+- Use fenced code blocks with a language hint:
+  - `shell` or `bash` for commands.
+  - `yaml`, `toml`, etc. for config.
+- Keep commands copy-pasteable:
+  - Include exact commands.
+  - Keep placeholders explicit, e.g. `<github-username>`.
+- Use inline code for:
+  - file paths (`scripts/bootstrap.sh`)
+  - commands (`chezmoi apply`)
+  - flags (`--debug`)
+  - directory names (`bin/`, `tests/`)
+
+## Warnings, notes, and safety
+
+This repo’s docs favor calm inline caution over heavy callout blocks.
+
+- Use short warning sentences near the relevant step.
+- State the condition and action clearly.
+- Prefer wording like:
+  - “Run `brew bundle` if a Brewfile is present.”
+  - “Install Homebrew (if not present).”
+- Reserve emphatic language (`IMPORTANT`, `MUST`) for genuinely destructive or irreversible steps.
+
+## Assumed reader knowledge
+
+Assume the reader:
+
+- Is comfortable with terminal basics and package managers.
+- Understands how to run scripts and read command output.
+- May be unfamiliar with this repo’s file naming and tool choices.
+
+Therefore:
+
+- Briefly define repo-specific conventions (for example `dot_*` file mapping).
+- Link tools on first mention.
+- Do not over-explain general shell fundamentals.
+
+## Terminology and naming
+
+- Use canonical tool names consistently: **chezmoi**, **mise**, **Homebrew**, **Warp**.
+- Use “dotfiles” for the repository contents.
+- Use “bootstrap script” for `scripts/bootstrap.sh`.
+- Use “smoke tests” for lightweight validation checks.
+- Prefer “apply” for synchronizing changes via chezmoi.
+
+## What to avoid
+
+- Vague instructions (“set things up as needed”).
+- Large unstructured text blocks with no headings.
+- Mixing multiple tasks in one step.
+- Inconsistent command styles (switching between pseudo-code and runnable commands).
+- Unexplained acronyms and internal shorthand.
+- “Cute” tone, jokes, or opinionated commentary that obscures action.
+
+## Documentation quality checklist
+
+Before merging docs, confirm:
+
+- Sections follow a clear scan-friendly structure.
+- Commands are runnable and include required placeholders.
+- Repo-specific terms are introduced once and reused consistently.
+- Any caution is placed at the exact step where it matters.
+- Testing/validation commands are provided when relevant.

--- a/dot_warp/private_themes/private_foo.md
+++ b/dot_warp/private_themes/private_foo.md
@@ -1,108 +1,55 @@
-Code	Color	Example	Preview
-39	Default foreground color
-echo -e "Default \e[39mDefault"
-Default Default
-30	Black
-echo -e "Default \e[30mBlack"
-Default Black
-31	Red
-echo -e "Default \e[31mRed"
-Default Red
-32	Green
-echo -e "Default \e[32mGreen"
-Default Green
-33	Yellow
-echo -e "Default \e[33mYellow"
-Default Yellow
-34	Blue
-echo -e "Default \e[34mBlue"
-Default Blue
-35	Magenta
-echo -e "Default \e[35mMagenta"
-Default Magenta
-36	Cyan
-echo -e "Default \e[36mCyan"
-Default Cyan
-37	Light gray
-echo -e "Default \e[37mLight gray"
-Default Light gray
-90	Dark gray
-echo -e "Default \e[90mDark gray"
-Default Dark gray
-91	Light red
-echo -e "Default \e[91mLight red"
-Default Light red
-92	Light green
-echo -e "Default \e[92mLight green"
-Default Light green
-93	Light yellow
-echo -e "Default \e[93mLight yellow"
-Default Light yellow
-94	Light blue
-echo -e "Default \e[94mLight blue"
-Default Light blue
-95	Light magenta
-echo -e "Default \e[95mLight magenta"
-Default Light magenta
-96	Light cyan
-echo -e "Default \e[96mLight cyan"
-Default Light cyan
-97	White
-echo -e "Default \e[97mWhite"
-Default White
-Background
+# ANSI color reference
 
-Code	Color	Example	Preview
-49	Default background color
-echo -e "Default \e[49mDefault"
-Default Default
-40	Black
-echo -e "Default \e[40mBlack"
-Default Black
-41	Red
-echo -e "Default \e[41mRed"
-Default Red
-42	Green
-echo -e "Default \e[42mGreen"
-Default Green
-43	Yellow
-echo -e "Default \e[43mYellow"
-Default Yellow
-44	Blue
-echo -e "Default \e[44mBlue"
-Default Blue
-45	Magenta
-echo -e "Default \e[45mMagenta"
-Default Magenta
-46	Cyan
-echo -e "Default \e[46mCyan"
-Default Cyan
-47	Light gray
-echo -e "Default \e[47mLight gray"
-Default Light gray
-100	Dark gray
-echo -e "Default \e[100mDark gray"
-Default Dark gray
-101	Light red
-echo -e "Default \e[101mLight red"
-Default Light red
-102	Light green
-echo -e "Default \e[102mLight green"
-Default Light green
-103	Light yellow
-echo -e "Default \e[103mLight yellow"
-Default Light yellow
-104	Light blue
-echo -e "Default \e[104mLight blue"
-Default Light blue
-105	Light magenta
-echo -e "Default \e[105mLight magenta"
-Default Light magenta
-106	Light cyan
-echo -e "Default \e[106mLight cyan"
-Default Light cyan
-107	White
-echo -e "Default \e[107mWhite"
-Default White
+Use this quick reference to preview ANSI foreground and background color codes in a shell.
 
-Write a regex to delete all lines that start with a number
+## Foreground colors
+
+| Code | Color | Example command |
+| ---: | --- | --- |
+| 39 | Default foreground color | `echo -e "Default \e[39mDefault"` |
+| 30 | Black | `echo -e "Default \e[30mBlack"` |
+| 31 | Red | `echo -e "Default \e[31mRed"` |
+| 32 | Green | `echo -e "Default \e[32mGreen"` |
+| 33 | Yellow | `echo -e "Default \e[33mYellow"` |
+| 34 | Blue | `echo -e "Default \e[34mBlue"` |
+| 35 | Magenta | `echo -e "Default \e[35mMagenta"` |
+| 36 | Cyan | `echo -e "Default \e[36mCyan"` |
+| 37 | Light gray | `echo -e "Default \e[37mLight gray"` |
+| 90 | Dark gray | `echo -e "Default \e[90mDark gray"` |
+| 91 | Light red | `echo -e "Default \e[91mLight red"` |
+| 92 | Light green | `echo -e "Default \e[92mLight green"` |
+| 93 | Light yellow | `echo -e "Default \e[93mLight yellow"` |
+| 94 | Light blue | `echo -e "Default \e[94mLight blue"` |
+| 95 | Light magenta | `echo -e "Default \e[95mLight magenta"` |
+| 96 | Light cyan | `echo -e "Default \e[96mLight cyan"` |
+| 97 | White | `echo -e "Default \e[97mWhite"` |
+
+## Background colors
+
+| Code | Color | Example command |
+| ---: | --- | --- |
+| 49 | Default background color | `echo -e "Default \e[49mDefault"` |
+| 40 | Black | `echo -e "Default \e[40mBlack"` |
+| 41 | Red | `echo -e "Default \e[41mRed"` |
+| 42 | Green | `echo -e "Default \e[42mGreen"` |
+| 43 | Yellow | `echo -e "Default \e[43mYellow"` |
+| 44 | Blue | `echo -e "Default \e[44mBlue"` |
+| 45 | Magenta | `echo -e "Default \e[45mMagenta"` |
+| 46 | Cyan | `echo -e "Default \e[46mCyan"` |
+| 47 | Light gray | `echo -e "Default \e[47mLight gray"` |
+| 100 | Dark gray | `echo -e "Default \e[100mDark gray"` |
+| 101 | Light red | `echo -e "Default \e[101mLight red"` |
+| 102 | Light green | `echo -e "Default \e[102mLight green"` |
+| 103 | Light yellow | `echo -e "Default \e[103mLight yellow"` |
+| 104 | Light blue | `echo -e "Default \e[104mLight blue"` |
+| 105 | Light magenta | `echo -e "Default \e[105mLight magenta"` |
+| 106 | Light cyan | `echo -e "Default \e[106mLight cyan"` |
+| 107 | White | `echo -e "Default \e[107mWhite"` |
+
+## Useful regex
+
+To delete all lines that start with a number, use:
+
+```regex
+^\d.*\n?
+```


### PR DESCRIPTION
### Motivation

- Provide a consistent, repository-wide writing standard so new docs follow predictable structure and tone.
- Surface the style guide from within the README to make documentation conventions discoverable.
- Replace an ad-hoc ANSI color cheat sheet with a clear, machine-readable reference and a useful regex example for editors.

### Description

- Normalized README headings to sentence case and made minor copy edits under `## Tooling overview`, `## Common chezmoi commands`, `## Repository layout`, `## Testing`, and `## Bootstrap script`.
- Added `docs/documentation-style-guide.md` with voice, structure, formatting, and checklist guidance for repository documentation.
- Inserted a `## Documentation` section in the README linking to the new style guide.
- Rewrote `dot_warp/private_themes/private_foo.md` into a structured ANSI color reference with foreground/background tables and a suggested regex to remove numbered lines.

### Testing

- Ran the repository smoke tests via `bats tests/smoke.bats` and they completed successfully.
- Ran script linting with `shellcheck install/*.sh scripts/**/*.sh` and no new issues were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4c6443268832f95f57f8042dfba56)