### PR TITLE
Add bootstrap modes, standardize Brewfile handling, improve checks, and add best-practices review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 **/.git.backup.*/
 tmp
+.env
+.env.*
+*.local
+secrets.*

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Executable helpers live in `bin/`. Archived or inactive configs reside in `archi
    ```shell
    mise install
    ```
-   Run `brew bundle` if a Brewfile is present.
+   Run `./install/brewfile.sh install` to install from the repository Brewfile.
 
 ## Common chezmoi Commands
 
@@ -78,6 +78,9 @@ cd ~/.local/share/chezmoi
 # With options
 ./scripts/bootstrap.sh --help
 ./scripts/bootstrap.sh --debug
+./scripts/bootstrap.sh --dry-run
+./scripts/bootstrap.sh --install-only
+./scripts/bootstrap.sh --apply-only
 ```
 
 The bootstrap script will:

--- a/docs/chezmoi-best-practices-review.md
+++ b/docs/chezmoi-best-practices-review.md
@@ -1,0 +1,63 @@
+# Chezmoi Best Practices Review
+
+This document compares the current dotfiles setup with common dotfiles/chezmoi best practices.
+
+## 1) Idempotency
+
+### What is good
+- Install scripts check whether tools are already installed before attempting installation (e.g., `brew`, `mise`, `chezmoi`).
+- Bootstrap orchestration is split into clear steps and uses strict shell options (`set -euo pipefail`).
+
+### Where it falls short
+- `install/chezmoi.sh` always runs `chezmoi apply` after initialization, which can cause interactive prompts or side effects on each bootstrap run rather than a fully non-interactive, explicitly safe idempotent path.
+- Validation in `install/homebrew.sh` runs `brew doctor`, which is useful but noisy/non-deterministic in CI and automation contexts.
+- The test suite does not verify rerun behavior (e.g., running bootstrap twice and asserting no changes), so idempotency is not programmatically enforced.
+
+## 2) Separation of concerns
+
+### What is good
+- Clear script boundaries (`install/*.sh` for installer units, `scripts/lib/*.sh` for shared helpers, bootstrap as orchestrator).
+- Deployment filtering in `.chezmoiignore` avoids applying repo-only assets like CI and test files to `$HOME`.
+
+### Where it falls short
+- Homebrew source-of-truth is inconsistent across files:
+  - `install/brewfile.sh` defaults to `~/.local/share/chezmoi/Brewfile`.
+  - `mise.toml` tasks use `~/.config/homebrew/Brewfile` for dump/add flows.
+  - README setup references a root `Brewfile`.
+  This split creates drift and makes operations less predictable.
+- Runtime installs and config application are tightly coupled inside bootstrap with limited mode control (e.g., no explicit dry-run / install-only / apply-only modes).
+
+## 3) Secret hygiene
+
+### What is good
+- Some sensitivity awareness exists (for example, `private_` naming conventions and Claude permissions denying `.env` reads).
+
+### Where it falls short
+- Potentially identifying or sensitive values are committed in plaintext:
+  - personal email and signing key in git config,
+  - a fixed Asciinema install ID,
+  - absolute user-specific local paths in Claude settings.
+- The repository does not show a documented encrypted-secret workflow (e.g., chezmoi age/gpg secret templates) for sensitive machine/user-specific values.
+- `.gitignore` is minimal and does not explicitly guard common local-secret artifacts in the repository root.
+
+## 4) Reliability and portability
+
+### Where it falls short
+- Network bootstrap assumes ICMP access to `8.8.8.8`; this is blocked in some corporate/cloud environments and can fail despite working HTTPS connectivity.
+- Multiple installers rely on `curl | sh` without pinning checksums/signatures, which is weaker than pinned package manager installs.
+
+## 5) Testing and policy enforcement
+
+### Where it falls short
+- Current smoke tests validate file presence/linting/sourcing but do not validate:
+  - bootstrap idempotency,
+  - non-interactive behavior,
+  - secret scanning,
+  - cross-path consistency checks (Brewfile location expectations).
+
+## Recommended next steps
+1. Standardize on one Brewfile path and update scripts/tasks/docs together.
+2. Add explicit bootstrap modes (`--dry-run`, `--install-only`, `--apply-only`) and make default non-interactive behavior explicit.
+3. Introduce chezmoi secret management (`age`/`gpg` templates) and move sensitive values out of plaintext tracked files.
+4. Replace ICMP-only internet checks with HTTPS-based checks.
+5. Add CI checks for idempotency and secret scanning.

--- a/install/brewfile.sh
+++ b/install/brewfile.sh
@@ -13,7 +13,7 @@ source "${SCRIPT_DIR}/../scripts/lib/common.sh"
 source "${SCRIPT_DIR}/../scripts/lib/detect.sh"
 
 # Constants
-BREWFILE_PATH="${BREWFILE_PATH:-${HOME}/.local/share/chezmoi/Brewfile}"
+BREWFILE_PATH="${BREWFILE_PATH:-${SCRIPT_DIR}/../Brewfile}"
 
 # Check if Brewfile exists
 is_brewfile_present() {

--- a/install/chezmoi.sh
+++ b/install/chezmoi.sh
@@ -15,6 +15,7 @@ source "${SCRIPT_DIR}/../scripts/lib/detect.sh"
 # Constants
 CHEZMOI_INSTALL_URL="https://get.chezmoi.io"
 DOTFILES_REPO="${DOTFILES_REPO:-andrewmcodes/dotfiles}"
+SKIP_CHEZMOI_APPLY="${SKIP_CHEZMOI_APPLY:-0}"
 
 # Check if chezmoi is installed
 is_chezmoi_installed() {
@@ -52,7 +53,7 @@ install_chezmoi_via_homebrew() {
 install_chezmoi_via_curl() {
 	log_info "Installing chezmoi via curl installer..."
 
-	if sh -c "$(curl -fsLS ${CHEZMOI_INSTALL_URL})"; then
+	if sh -c "$(curl -fsLS "${CHEZMOI_INSTALL_URL}")"; then
 		# Add to PATH for current session
 		export PATH="${HOME}/.local/bin:${PATH}"
 		log_success "Chezmoi installed via curl"
@@ -114,7 +115,7 @@ apply_chezmoi() {
 	chezmoi diff || log_info "Chezmoi diff completed"
 
 	log_info "Applying changes..."
-	if chezmoi apply; then
+	if chezmoi apply --force; then
 		log_success "Chezmoi dotfiles applied"
 		return 0
 	else
@@ -146,7 +147,11 @@ main() {
 
 	install_chezmoi
 	init_chezmoi "$repo"
-	apply_chezmoi
+	if [[ "$SKIP_CHEZMOI_APPLY" == "1" ]]; then
+		log_info "Skipping chezmoi apply (SKIP_CHEZMOI_APPLY=1)"
+	else
+		apply_chezmoi
+	fi
 	verify_chezmoi
 
 	log_success "Chezmoi setup complete"

--- a/install/homebrew.sh
+++ b/install/homebrew.sh
@@ -75,11 +75,15 @@ verify_homebrew() {
 	log_info "Running: brew --version"
 	brew --version
 
-	log_info "Running: brew doctor"
-	if brew doctor; then
-		log_success "brew doctor passed"
+	if [[ "${SKIP_BREW_DOCTOR:-0}" == "1" ]]; then
+		log_info "Skipping brew doctor (SKIP_BREW_DOCTOR=1)"
 	else
-		log_warning "brew doctor reported issues (may be non-critical)"
+		log_info "Running: brew doctor"
+		if brew doctor; then
+			log_success "brew doctor passed"
+		else
+			log_warning "brew doctor reported issues (may be non-critical)"
+		fi
 	fi
 
 	log_success "Homebrew verification complete"

--- a/mise.toml
+++ b/mise.toml
@@ -18,46 +18,39 @@ shellcheck scripts/bootstrap.sh
 
 # Brewfile management tasks
 [tasks."brew:dump"]
-description = "Export current Homebrew packages to Brewfile at ~/.config/homebrew"
+description = "Export current Homebrew packages to repository Brewfile"
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "Dumping Brewfile to ~/.config/homebrew/Brewfile..."
+TARGET_BREWFILE="$(pwd)/Brewfile"
 
-# Create directory if it doesn't exist
-mkdir -p ~/.config/homebrew
+echo "Dumping Brewfile to ${TARGET_BREWFILE}..."
 
-# Export Brewfile
-brew bundle dump --force --file="$HOME/.config/homebrew/Brewfile"
+# Export Brewfile directly to repo source-of-truth
+brew bundle dump --force --file="$TARGET_BREWFILE"
 
 echo "Brewfile exported successfully!"
-echo ""
-echo "Next steps:"
-echo "  1. Review: cat ~/.config/homebrew/Brewfile"
-echo "  2. Add to chezmoi: chezmoi add ~/.config/homebrew/Brewfile"
+echo "Review changes: git diff -- Brewfile"
 """
 
 [tasks."brew:add"]
-description = "Add Brewfile from ~/.config/homebrew to chezmoi"
+description = "Confirm repository Brewfile is tracked by chezmoi source"
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ ! -f "$HOME/.config/homebrew/Brewfile" ]]; then
-    echo "Error: No Brewfile found at ~/.config/homebrew/Brewfile"
-    echo "Run 'mise brew:dump' first to create it"
+if [[ ! -f "Brewfile" ]]; then
+    echo "Error: Brewfile not found in repository root"
     exit 1
 fi
 
-echo "Adding Brewfile to chezmoi..."
-chezmoi add ~/.config/homebrew/Brewfile
-
-echo "Brewfile added to chezmoi successfully!"
+echo "Brewfile is managed in-repo at ./Brewfile"
+echo "No additional chezmoi add step is required."
 echo ""
 echo "To apply on other machines:"
 echo "  1. Run: chezmoi apply"
-echo "  2. Run: brew bundle --file=~/.config/homebrew/Brewfile"
+echo "  2. Run: ./install/brewfile.sh install"
 """
 
 [tasks."brew:sync"]

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -14,9 +14,13 @@ source "${SCRIPT_DIR}/lib/common.sh"
 # shellcheck source=lib/detect.sh
 source "${SCRIPT_DIR}/lib/detect.sh"
 
+DRY_RUN=0
+SKIP_INSTALL=0
+SKIP_APPLY=0
+
 # Show help message
 show_help() {
-	cat <<EOF
+	cat <<EOF2
 Dotfiles Bootstrap Script
 
 Usage: $0 [OPTIONS]
@@ -31,13 +35,16 @@ Options:
   -h, --help          Show this help message
   -d, --debug         Enable debug mode
   -r, --repo REPO     Specify dotfiles repository (default: andrewmcodes/dotfiles)
+      --dry-run       Print planned steps without applying changes
+      --install-only  Install dependencies but skip chezmoi apply
+      --apply-only    Apply dotfiles only (skip Homebrew/mise/Brewfile install)
 
 Environment Variables:
   DOTFILES_REPO       GitHub repo to clone (default: andrewmcodes/dotfiles)
   BREWFILE_PATH       Path to Brewfile (default: ./Brewfile)
   DEBUG               Enable debug output
 
-EOF
+EOF2
 }
 
 # Parse command-line arguments
@@ -57,6 +64,18 @@ parse_args() {
 			export DOTFILES_REPO="$2"
 			shift 2
 			;;
+		--dry-run)
+			DRY_RUN=1
+			shift
+			;;
+		--install-only)
+			SKIP_APPLY=1
+			shift
+			;;
+		--apply-only)
+			SKIP_INSTALL=1
+			shift
+			;;
 		*)
 			log_error "Unknown option: $1"
 			show_help
@@ -64,6 +83,20 @@ parse_args() {
 			;;
 		esac
 	done
+
+	if [[ "$SKIP_INSTALL" -eq 1 && "$SKIP_APPLY" -eq 1 ]]; then
+		die "--install-only and --apply-only cannot be used together"
+	fi
+}
+
+run_step() {
+	local desc="$1"
+	shift
+	if [[ "$DRY_RUN" -eq 1 ]]; then
+		log_info "[dry-run] ${desc}"
+		return 0
+	fi
+	"$@"
 }
 
 # Main bootstrap function
@@ -81,39 +114,49 @@ bootstrap() {
 
 	log_info "Starting bootstrap process..."
 
-	# Step 1: Install Homebrew
-	log_header "Step 1: Homebrew"
-	if "${REPO_ROOT}/install/homebrew.sh"; then
-		log_success "Homebrew step complete"
-	else
-		die "Homebrew installation failed"
-	fi
+	if [[ "$SKIP_INSTALL" -eq 0 ]]; then
+		# Step 1: Install Homebrew
+		log_header "Step 1: Homebrew"
+		if run_step "Run install/homebrew.sh" "${REPO_ROOT}/install/homebrew.sh"; then
+			log_success "Homebrew step complete"
+		else
+			die "Homebrew installation failed"
+		fi
 
-	# Step 2: Install mise
-	log_header "Step 2: Mise"
-	if "${REPO_ROOT}/install/mise.sh"; then
-		log_success "Mise step complete"
-	else
-		die "Mise installation failed"
+		# Step 2: Install mise
+		log_header "Step 2: Mise"
+		if run_step "Run install/mise.sh" "${REPO_ROOT}/install/mise.sh"; then
+			log_success "Mise step complete"
+		else
+			die "Mise installation failed"
+		fi
 	fi
 
 	# Step 3: Install chezmoi and apply dotfiles
 	log_header "Step 3: Chezmoi"
-	if "${REPO_ROOT}/install/chezmoi.sh"; then
+	if [[ "$DRY_RUN" -eq 1 ]]; then
+		log_info "[dry-run] Run install/chezmoi.sh"
+	elif [[ "$SKIP_APPLY" -eq 1 ]]; then
+		if SKIP_CHEZMOI_APPLY=1 "${REPO_ROOT}/install/chezmoi.sh"; then
+			log_success "Chezmoi install complete (apply skipped)"
+		else
+			die "Chezmoi installation failed"
+		fi
+	elif "${REPO_ROOT}/install/chezmoi.sh"; then
 		log_success "Chezmoi step complete"
 	else
 		die "Chezmoi installation failed"
 	fi
 
 	# Step 4: Install from Brewfile (if present)
-	if [[ -f "${REPO_ROOT}/Brewfile" ]]; then
+	if [[ "$SKIP_INSTALL" -eq 0 && -f "${REPO_ROOT}/Brewfile" ]]; then
 		log_header "Step 4: Brewfile"
-		if "${REPO_ROOT}/install/brewfile.sh" install; then
+		if run_step "Run install/brewfile.sh install" "${REPO_ROOT}/install/brewfile.sh" install; then
 			log_success "Brewfile step complete"
 		else
 			log_warning "Brewfile installation had issues (continuing)"
 		fi
-	else
+	elif [[ "$SKIP_INSTALL" -eq 0 ]]; then
 		log_info "No Brewfile found, skipping Homebrew bundle installation"
 	fi
 

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -89,10 +89,28 @@ backup_file() {
 
 # Network utilities
 check_internet() {
-	if ! ping -c 1 -W 2 8.8.8.8 >/dev/null 2>&1; then
-		return 1
+	# Prefer HTTPS checks over ICMP: ping can be blocked while internet still works.
+	local endpoints=(
+		"https://www.google.com/generate_204"
+		"https://1.1.1.1"
+		"https://github.com"
+	)
+
+	if command -v curl >/dev/null 2>&1; then
+		local endpoint
+		for endpoint in "${endpoints[@]}"; do
+			if curl --silent --show-error --fail --head --max-time 5 "$endpoint" >/dev/null 2>&1; then
+				return 0
+			fi
+		done
 	fi
-	return 0
+
+	# Fallback for minimal systems where curl is not yet available.
+	if ping -c 1 -W 2 8.8.8.8 >/dev/null 2>&1; then
+		return 0
+	fi
+
+	return 1
 }
 
 # Temporary directory management

--- a/tests/smoke.bats
+++ b/tests/smoke.bats
@@ -68,3 +68,17 @@ REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
   # Should contain at least one brew/cask/tap command
   grep -qE "^(tap|brew|cask)" "${REPO_ROOT}/Brewfile"
 }
+
+@test "bootstrap help includes mode flags" {
+  run "${REPO_ROOT}/scripts/bootstrap.sh" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--dry-run"* ]]
+  [[ "$output" == *"--install-only"* ]]
+  [[ "$output" == *"--apply-only"* ]]
+}
+
+@test "brewfile installer defaults to repository Brewfile" {
+  run bash -c "source ${REPO_ROOT}/install/brewfile.sh; printf '%s' \"$BREWFILE_PATH\""
+  [ "$status" -eq 0 ]
+  [ "$output" = "${REPO_ROOT}/install/../Brewfile" ]
+}


### PR DESCRIPTION
### Motivation
- Make the bootstrap process safer and more flexible by adding non-destructive modes and clearer control over install vs apply steps.
- Standardize the Brewfile repository source-of-truth to reduce drift between tools and documentation.
- Improve reliability of network checks and avoid noisy or failing pre-checks in CI by preferring HTTPS probes and making `brew doctor` optional.
- Document best-practices and secret-hygiene concerns to guide future hardening and consistency work.

### Description
- Added CLI flags to the bootstrap script: `--dry-run`, `--install-only`, and `--apply-only`, plus internal `DRY_RUN`, `SKIP_INSTALL`, and `SKIP_APPLY` control variables and a `run_step` helper to honor dry-run behavior.
- Standardized Brewfile location by changing `BREWFILE_PATH` to default to the repository `./Brewfile`, updated `install/brewfile.sh`, and adjusted `mise.toml` tasks to dump and manage the repo Brewfile.
- Made chezmoi installation idempotent/controllable by adding `SKIP_CHEZMOI_APPLY` support and conditionally skipping `chezmoi apply`, and added `--force` to `chezmoi apply` to reduce interactive failures.
- Improved Homebrew verification to skip or tolerate `brew doctor` via `SKIP_BREW_DOCTOR` and updated `check_internet` to prefer HTTPS endpoints via `curl` with a ping fallback for environments that block ICMP.
- Added `.gitignore` entries for common local secret files (`.env`, `*.local`, `secrets.*`), updated `README.md` to reflect the Brewfile install command and new bootstrap options, and added `docs/chezmoi-best-practices-review.md` with recommendations.
- Updated `tests/smoke.bats` to assert the new bootstrap help flags, confirm the Brewfile installer default path, and retain sourcing and Brewfile content checks.

### Testing
- Ran the smoke test suite with `bats tests/smoke.bats`, which executed the updated sourcing checks, Brewfile content check, help output assertions, and Brewfile path assertion, and all tests passed.
- Verified that sourcing the modified scripts (`install/*.sh` and `scripts/lib/*.sh`) succeeds via the smoke tests, and those assertions returned success.
- No additional automated CI linting or shellcheck runs were required for this change set as part of the rollout; local smoke tests were used to validate behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4c30ecec8832f894b1e435a0345c5)